### PR TITLE
Yesod 0.9, yesod-core 0.9, http-enumerator 0.7

### DIFF
--- a/yackage.cabal
+++ b/yackage.cabal
@@ -27,7 +27,8 @@ Executable yackage
   Main-is:             yackage.hs
   if flag(yackage)
       Build-depends:       base >= 4 && < 5
-                         , yesod-core >= 0.8 && < 0.9
+                         , yesod >= 0.9 && < 0.10
+                         , yesod-core >= 0.9 && < 0.10
                          , warp
                          , Cabal
                          , bytestring
@@ -41,9 +42,6 @@ Executable yackage
                          , cmdargs
                          , wai
                          , transformers
-                         , hamlet
-                         , yesod-form >= 0.2 && < 0.3
-                         , http-types >= 0.6 && < 0.7
   else
     Buildable: False
 
@@ -51,7 +49,7 @@ Executable yackage-upload
   Main-is:             yackage-upload.hs
   if flag(upload)
       Build-depends:       base >= 4 && < 5
-                         , http-enumerator >= 0.6 && < 0.7
+                         , http-enumerator >= 0.6 && < 0.8
                          , blaze-builder >= 0.2.1.3 && < 0.4
                          , bytestring
   else

--- a/yackage.hs
+++ b/yackage.hs
@@ -2,15 +2,9 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+import Yesod
 import Yesod.Core
 import Yesod.Dispatch
-import Yesod.Handler
-import Yesod.Widget
-import Yesod.Content
-import Yesod.Form
-import Yesod.Request
-import Text.Hamlet
-import Control.Monad.IO.Class (liftIO)
 import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Parse
@@ -37,9 +31,7 @@ import Data.Object
 import Data.Object.Yaml
 import Control.Monad (join, unless)
 import System.Console.CmdArgs
-import Network.Wai
 import Network.Wai.Handler.Warp (runSettings, defaultSettings, settingsPort, settingsHost)
-import Network.HTTP.Types (status403)
 import qualified Data.Text as T
 
 data Args = Args
@@ -104,14 +96,14 @@ instance SinglePiece PackageName where
     fromSinglePiece = Just . PackageName . T.unpack
     toSinglePiece = T.pack . unPackageName
 
-type Handler = GHandler Yackage Yackage
+type YHandler = GHandler Yackage Yackage
 
-getRootR :: Handler RepHtml
+getRootR :: YHandler RepHtml
 getRootR = do
     y <- getYesod
     ps <- getYesod >>= liftIO . readMVar . packages >>= return . Map.toList
     defaultLayout $ do
-        setTitle $ string $ ytitle y
+        setTitle $ toHtml $ ytitle y
         addHamlet [$hamlet|\
 <h1>#{ytitle y}
 <form method="post" enctype="multipart/form-data">


### PR DESCRIPTION
Small changes to make it compatible with Yesod 0.9, yesod-core 0.9 and http-enumerator 0.7.

The dependency list in yackage.cabal has changed. Appart from version numbers, I added yesod (to use toHtml) and removed yesod-form, hamlet and http-types (they are indirect dependencies).

I did not increase the version number in the cabal file.
