### PR TITLE
Change absolute paths to relative for index

### DIFF
--- a/yackage.hs
+++ b/yackage.hs
@@ -244,8 +244,7 @@ rebuildIndex ps = do
     cabals path = concatMap (go path) $ Map.toList ps
     go path (name, vs) = map (go' path name) $ Set.toList vs
     go' path name version = concat
-        [ path
-        , '/' : T.unpack (toPathPiece name)
+        [ T.unpack (toPathPiece name)
         , '/' : T.unpack (toPathPiece version)
         , '/' : cabalName name version
         ]

--- a/yackage.hs
+++ b/yackage.hs
@@ -241,9 +241,9 @@ rebuildIndex ps = do
             else fp
       where
         path' = path ++ "/"
-    cabals path = concatMap (go path) $ Map.toList ps
-    go path (name, vs) = map (go' path name) $ Set.toList vs
-    go' path name version = concat
+    cabals path = concatMap go $ Map.toList ps
+    go (name, vs) = map (go' name) $ Set.toList vs
+    go' name version = concat
         [ T.unpack (toPathPiece name)
         , '/' : T.unpack (toPathPiece version)
         , '/' : cabalName name version


### PR DESCRIPTION
Currently the index tar that is made is tarred with the absolute
filepaths of all the .cabal files that go into the tar. While this works
fine on Unix-y machines, for some reason this introduces problems on
Windows where the absolute path turns into "C: \Users..." (with an
extra space there), which makes yackage unusable on Windows. By changing
the paths of the .cabal files to be relative, we nicely sidestep this
problem.
